### PR TITLE
Minor typos and Minor code refactor of fracture and stm_fracture_eat_a_chunk functions

### DIFF
--- a/addons/smash_the_mesh/stm_fracture_tool.gd
+++ b/addons/smash_the_mesh/stm_fracture_tool.gd
@@ -99,17 +99,22 @@ func fracture(chunk_mesh: Mesh, chunks_count: Vector3i, opt: Dictionary):
 	var x_range = range(chunks_count.x)
 	
 	var shuffle: bool = opt.random_sampling
-	
-	var start_time = Time.get_ticks_msec()
+
+	if shuffle:
+		var y_amount = z_range.size() * y_range.size()
+		var x_amount = z_range.size() * y_range.size() * x_range.size()
+
+		z_range.shuffle()
+		for i in range(y_amount):
+			y_range.shuffle()
+		for i in range(x_amount):
+			x_range.shuffle()
 
 	var chunk_positions = PackedVector3Array()
-	if shuffle: z_range.shuffle()
 	for z in z_range:
 		chunk_position.z = chunk_center.z + z * chunk_size.z
-		if shuffle: y_range.shuffle()
 		for y in y_range:
 			chunk_position.y = chunk_center.y + y * chunk_size.y
-			if shuffle: x_range.shuffle()
 			for x in x_range:
 				chunk_position.x = chunk_center.x + x * chunk_size.x
 				print("\t\t# computing chunk ", idx, "/", count)
@@ -117,10 +122,6 @@ func fracture(chunk_mesh: Mesh, chunks_count: Vector3i, opt: Dictionary):
 				chunk_positions.push_back(chunk_position)
 
 	chunks = stm_fracture_eat_a_chunk(chunk_positions, chunk_data)
-	
-	var end_time = Time.get_ticks_msec()
-	var duration = end_time - start_time
-	print("Elapsed Time: ", duration)
 				
 	return chunks
 

--- a/addons/smash_the_mesh/stm_fracture_tool.gd
+++ b/addons/smash_the_mesh/stm_fracture_tool.gd
@@ -100,21 +100,14 @@ func fracture(chunk_mesh: Mesh, chunks_count: Vector3i, opt: Dictionary):
 	
 	var shuffle: bool = opt.random_sampling
 
-	if shuffle:
-		var y_amount = z_range.size() * y_range.size()
-		var x_amount = z_range.size() * y_range.size() * x_range.size()
-
-		z_range.shuffle()
-		for i in range(y_amount):
-			y_range.shuffle()
-		for i in range(x_amount):
-			x_range.shuffle()
-
 	var chunk_positions = PackedVector3Array()
+	if shuffle: z_range.shuffle()
 	for z in z_range:
 		chunk_position.z = chunk_center.z + z * chunk_size.z
+		if shuffle: y_range.shuffle()
 		for y in y_range:
 			chunk_position.y = chunk_center.y + y * chunk_size.y
+			if shuffle: x_range.shuffle()
 			for x in x_range:
 				chunk_position.x = chunk_center.x + x * chunk_size.x
 				print("\t\t# computing chunk ", idx, "/", count)

--- a/addons/smash_the_mesh/stm_instance.gd
+++ b/addons/smash_the_mesh/stm_instance.gd
@@ -178,7 +178,7 @@ signal on_fracture_param_changed
 #---------------------------------------------------------------------------------------------------
 
 # This node will hold all the rigid bodies chunks after you call "smash_the_mesh()" otherwise
-# it will be null. If you want to iterate over the rigid-bodies it's adisable to call
+# it will be null. If you want to iterate over the rigid-bodies it's advisable to call
 # chunks_iterate() instead with a callback.
 # Neverthelss the structure of a chunk is the following:
 # rb_parent(the root for all) > RigidBody3D(the first node of each chunk) > CollisionShape3D > MeshInstance3D
@@ -304,7 +304,7 @@ func smash_the_mesh():
 			rb.angular_velocity += rb_ancestor.angular_velocity * 0.1
 
 # This is an helper method to automatically add a rigid body and a collision shape 
-# this this instance. It will use the same physics settings of the chunks.
+# on this instance. It will use the same physics settings of the chunks.
 func add_physics_to_self():
 	var rb_ancestor = $"../.." as RigidBody3D
 	if !rb_ancestor: rb_ancestor = $".." as RigidBody3D	


### PR DESCRIPTION
stm_fracture_eat_a_chunk function processes all the chunk positions and returns an array of chunks, instead of processing them one by one.